### PR TITLE
windows linefeed fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# source: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+# Set the default behavior, in case people don't have core.autocrlf set.
+* binary
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+#*.c text
+#*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+#*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+#*.png binary
+#*.jpg binary


### PR DESCRIPTION
When checking out under windows, git might do some magic stuff with the line-endings.
In this specific case, you dont want that. as it will result in 'windows lineendings' being copied into dockerfiles deriving from linux base images.
For now, I just made everything binary, This worked on my machine
https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
